### PR TITLE
Data record layer and roadmap doc

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,20 @@
+# FAIR Datapoint Specification Roadmap
+This document aims to lay out the medium to long-term future plans for the FDP specification.
+
+## Metadata of metadata
+The current (meta)data model mixes metadata (about the data) and 'metadata metadata' (metadata about the metadata: provenance, etc.). To separate these layers, a distinct description of a layer's metadata could be added.
+
+## Standardized navigational model
+The current (meta)data model uses [DCAT](https://www.w3.org/TR/vocab-dcat/) with some custom additions ([re3data](https://www.re3data.org/) etc.). To facilitate a broader uptake by existing client libraries, a standardized navigational model ([LDP](https://www.w3.org/TR/ldp/), [Hydra](http://www.hydra-cg.com/), etc.) could be considered.
+
+## Conditions of use
+To communicate to a human user what the conditions are for using the (meta)data, or to allow the FAIR Data Point to act in a Personal Health Train environment for automated reasoning, a clear description of conditions of use should be made available.
+
+## FAIR-Metrics
+To comply with the [FAIR Metrics](http://fairmetrics.org/), the (meta)data model should provide information in a way the evaluator implementations can understand.
+
+## Versioning
+To make a distinction between versions (of a dataset), there needs to be additional metadata in (or more fundamental changes to) the model. Both the [DCAT revised edition](https://w3c.github.io/dxwg/dcat/#dataset-versions) specification and the [DXWG wiki on versioning](https://github.com/w3c/dxwg/wiki/Dataset-%28and-other-DCAT%29-versioning) contain sections on versioning that could be followed.
+
+## Custom metadata extensions
+Currently the (meta)data model defines a minimal set of properties to describe the repository and its content. User-defined (extensions to the existing) properties are not considered. To allow for user extensions, the model could provide (among other things) standard mechanisms for describing an extension.

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,20 +1,27 @@
 # FAIR Datapoint Specification Roadmap
 This document aims to lay out the medium to long-term future plans for the FDP specification.
 
-## Metadata of metadata
+## [Metadata of metadata]
 The current (meta)data model mixes metadata (about the data) and 'metadata metadata' (metadata about the metadata: provenance, etc.). To separate these layers, a distinct description of a layer's metadata could be added.
 
-## Standardized navigational model
+## [Standardized navigational model]
 The current (meta)data model uses [DCAT](https://www.w3.org/TR/vocab-dcat/) with some custom additions ([re3data](https://www.re3data.org/) etc.). To facilitate a broader uptake by existing client libraries, a standardized navigational model ([LDP](https://www.w3.org/TR/ldp/), [Hydra](http://www.hydra-cg.com/), etc.) could be considered.
 
-## Conditions of use
+## [Conditions of use]
 To communicate to a human user what the conditions are for using the (meta)data, or to allow the FAIR Data Point to act in a Personal Health Train environment for automated reasoning, a clear description of conditions of use should be made available.
 
-## FAIR-Metrics
+## [FAIR-Metrics]
 To comply with the [FAIR Metrics](http://fairmetrics.org/), the (meta)data model should provide information in a way the evaluator implementations can understand.
 
-## Versioning
+## [Versioning]
 To make a distinction between versions (of a dataset), there needs to be additional metadata in (or more fundamental changes to) the model. Both the [DCAT revised edition](https://w3c.github.io/dxwg/dcat/#dataset-versions) specification and the [DXWG wiki on versioning](https://github.com/w3c/dxwg/wiki/Dataset-%28and-other-DCAT%29-versioning) contain sections on versioning that could be followed.
 
-## Custom metadata extensions
+## [Custom metadata extensions]
 Currently the (meta)data model defines a minimal set of properties to describe the repository and its content. User-defined (extensions to the existing) properties are not considered. To allow for user extensions, the model could provide (among other things) standard mechanisms for describing an extension.
+
+[Metadata of metadata]: https://github.com/FAIRDataTeam/FAIRDataPoint-Spec/issues/7
+[Standardized navigational model]: https://github.com/FAIRDataTeam/FAIRDataPoint-Spec/issues/8
+[Conditions of use]: https://github.com/FAIRDataTeam/FAIRDataPoint-Spec/issues/9
+[FAIR-Metrics]: https://github.com/FAIRDataTeam/FAIRDataPoint-Spec/issues/10
+[Versioning]: https://github.com/FAIRDataTeam/FAIRDataPoint-Spec/issues/11
+[Custom metadata extensions]: https://github.com/FAIRDataTeam/FAIRDataPoint-Spec/issues/12

--- a/spec.md
+++ b/spec.md
@@ -14,6 +14,7 @@ Table of contents
   - [Catalog metadata layer](#catalog-metadata-layer)
   - [Dataset metadata layer](#dataset-metadata-layer)
   - [Distribution metadata layer](#distribution-metadata-layer)
+  - [Data record metadata layer](#data-record-metadata-layer)
 - [Access rights rdf model](#access-rights-rdf-model)
 
 ## FAIR Data Point metadata layer
@@ -294,6 +295,57 @@ An example of distribution metadata.
 <http://136.243.4.200:8087/fdp/distribution/gene_disease_association_nquads_gzip#accessRights>
   a dcterms:RightsStatement;
   dcterms:description "This resource has no access restriction" .
+```
+
+### Data record metadata layer
+The data record metadata aims to describe a [distribution's](#distribution-metadata-layer) data on the format content level. The specification of this layer is still a work in progress. The model as described below is a draft of the data record metadata.
+
+Ontology     | Term name              | DataType   | Required/Optional | Description
+---          | ---                    | --------   |---                | ---
+RDF          | rdf:type               | IRI        | `Required`        | Required to be of type `fdp:DataRecord`
+DC terms     | dct:title              | String     | `Required`        | Name of the datarecord with the language tag
+|            | dct:conformsTo         | IRI        | Optional          | The specification of the datarecord metadata schema (for example ShEx)
+|            | dct:license            | IRI        | `Required`        | Link to the license description
+|            | dct:hasVersion         | String     | `Required`        | Version of the datarecord
+|            | dct:issued             | DateTime   | Optional          | Created date of the rml mappings
+|            | dct:modified           | DateTime   | Optional          | Last modified date of the rml mappings
+|            | dct:rights             | IRI        | Optional          | 
+|            | dct:description        | String     | Optional          | Description of the description with the language tag
+|            | dct:accessRights       | IRI        | Optional          | Description of the access rights, see [Access rights rdf model](#access-rights-rdf-model)
+|            | dct:isPartOf           | IRI        | `Required`        | Relation to the parent metadata.
+FDP ontology | fdp:metadataIdentifier | IRI        | `Required`        | Identifier of the metadata entry. Define new sub property ‘metadataID’ for dct:identifier 
+|            | fdp:metadataIssued     | DateTime   | `Required`        | Created date of the metadata entry
+|            | fdp:metadataModified   | DateTime   | `Required`        | Last modified date of the metadata entry
+|            | fdp:rmlMapping         | IRI        | `Required`        | Link to the generic rml mapping
+|            | fdp:rmlInputSource     | IRI        | Optional          | Distribution used to generate RDF
+RDF Schema   | rdfs:label             | String     | Optional          | Name of the data datarecord with the language tag
+
+An example of data record metadata
+```ttl
+@prefix fdp: <http://rdf.biosemantics.org/ontologies/fdp-o#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lang: <http://id.loc.gov/vocabulary/iso639-1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<> dct:title "An example data record metadata" ;
+    rdfs:label "An example data record metadata" ;
+    <http://rdf.biosemantics.org/ontologies/fdp-o#metadataIssued> "2016-10-27"^^xsd:date ;
+    <http://rdf.biosemantics.org/ontologies/fdp-o#metadataIdentifier> <http://dev-vm.fair-dtls.surf-hosted.nl:8082/fdp/dataRecord-metadataID> ;
+    <http://rdf.biosemantics.org/ontologies/fdp-o#metadataModified> "2016-10-27"^^xsd:date ;
+    a fdp:DataRecord ; 
+    dct:identifier "dataRecord" ;
+    dct:language lang:en  ;
+    dct:hasVersion "1.0" ;
+    dct:publisher   <http://dtls.nl> ;
+    fdp:rmlMapping <https://git.lumc.nl/biosemantics/ring14-fdp-metadata/raw/bd01b84fb792ae3860fdda646e9cb96a1a11205c/rml/biobank/RING_14_biobank_mapping.ttl> ;
+    fdp:rmlInputSource <http://localhost.com/an-example-distribution>  .
+
+<http://dev-vm.fair-dtls.surf-hosted.nl:8082/fdp/dataRecord-metadataID> a <http://purl.org/spar/datacite/ResourceIdentifier> ;
+    dct:identifier "dataRecord-metadataID" .
+
+<http://dtls.nl> a foaf:Organization;
+    foaf:name "DTLS"@en.
 ```
 
 ## Access rights rdf model


### PR DESCRIPTION
I've added the data record layer back to prepare for the next release cycle, and I've added a roadmap document that links out to the github issues created per topic.

The issues could contain any discussion from the community, and the document could record the conclusions or decisions.